### PR TITLE
fix unindexed array warning when wooCommerce not installed

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WpssoCompat' ) ) {
 			/*
 			 * WooCommerce.
 			 */
-			if ( $this->p->avail[ 'ecom' ][ 'woocommerce' ] ) {
+			if ( $this->p->avail[ 'ecom' ][ 'woocommerce' ] ?? FALSE ) {
 
 				add_filter( 'woocommerce_structured_data_product', '__return_empty_array', PHP_INT_MAX );
 				add_filter( 'woocommerce_structured_data_review', '__return_empty_array', PHP_INT_MAX );

--- a/lib/util.php
+++ b/lib/util.php
@@ -201,7 +201,7 @@ if ( ! class_exists( 'WpssoUtil' ) ) {
 			/*
 			 * Instantiate WpssoUtilWooCommerce.
 			 */
-			if ( $this->p->avail[ 'ecom' ][ 'woocommerce' ] ) {
+			if ( $this->p->avail[ 'ecom' ][ 'woocommerce' ] ?? FALSE ) {
 
 				if ( ! class_exists( 'WpssoUtilWooCommerce' ) ) {
 


### PR DESCRIPTION
When WooCommerce isn't installed, any use of `wp-cli` with wpsso installed gives a PHP warning:

```
PHP Warning:  Trying to access array offset on value of type null in mysite/wp-content/plugins/wpsso/lib/compat.php on line 63 
```

This fixes the warnings.